### PR TITLE
get Child data in crm.api.doc.get_data

### DIFF
--- a/crm/api/doc.py
+++ b/crm/api/doc.py
@@ -303,6 +303,26 @@ def get_data(
 			page_length=page_length,
 		) or []
 
+
+		# Fetch child table data if requested
+		include_child_tables = frappe.get_all('Data Doctype', fields=['name'])
+		include_child_tables_list = [entry['name'] for entry in include_child_tables]
+
+		if doctype in include_child_tables_list:
+			meta = frappe.get_meta(doctype)
+			child_tables = [df for df in meta.fields if df.fieldtype == "Table"]
+
+			for record in data:
+				record['child_tables'] = {}
+				for child_table in child_tables:
+					child_doctype = child_table.options
+					child_records = frappe.get_all(
+						child_doctype,
+						fields="*",
+						filters={"parent": record['name']}
+					)
+					record['child_tables'][child_table.fieldname] = child_records
+
 	if view_type == "kanban":
 		if not rows:
 			rows = default_rows

--- a/crm/api/doc.py
+++ b/crm/api/doc.py
@@ -310,7 +310,7 @@ def get_data(
 
 		if doctype in include_child_tables_list:
 			meta = frappe.get_meta(doctype)
-			child_tables = [df for df in meta.fields if df.fieldtype == "Table"]
+			child_tables = [df for df in meta.fields if df.fieldtype in ["Table","Table MultiSelect" ] ]
 
 			for record in data:
 				record['child_tables'] = {}

--- a/crm/fcrm/doctype/data_doctype/data_doctype.js
+++ b/crm/fcrm/doctype/data_doctype/data_doctype.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Data Doctype", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/crm/fcrm/doctype/data_doctype/data_doctype.json
+++ b/crm/fcrm/doctype/data_doctype/data_doctype.json
@@ -1,0 +1,46 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:data_doctype",
+ "creation": "2024-10-18 05:14:39.520861",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "data_doctype"
+ ],
+ "fields": [
+  {
+   "fieldname": "data_doctype",
+   "fieldtype": "Link",
+   "label": "Data Doctype",
+   "link_filters": "[[\"DocType\",\"istable\",\"=\",0],[\"DocType\",\"issingle\",\"=\",0]]",
+   "options": "DocType",
+   "unique": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-10-18 05:16:12.696953",
+ "modified_by": "Administrator",
+ "module": "FCRM",
+ "name": "Data Doctype",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/crm/fcrm/doctype/data_doctype/data_doctype.py
+++ b/crm/fcrm/doctype/data_doctype/data_doctype.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class DataDoctype(Document):
+	pass


### PR DESCRIPTION
This pull request enhances the **crm.api.doc.get_data ** function to support fetching child table data when requested. It introduces a mechanism to:

Check if the requested doctype is associated with child tables.
Retrieve metadata for the doctype and identify child table fields.
For each record, query and append relevant child table records to a new child_tables field, ensuring a complete dataset for complex document types.
These improvements streamline the retrieval of nested data, enhancing the API's flexibility and usability in CRM systems.
![image](https://github.com/user-attachments/assets/48218aa7-6fa3-4b80-bd37-d1ca284cae96)

![image](https://github.com/user-attachments/assets/c205fe7c-5c83-4d74-9065-fe8b0830da2d)
