### PR TITLE
Scrum 13/scrum 70

### DIFF
--- a/crm/fcrm/doctype/crm_deal/api.py
+++ b/crm/fcrm/doctype/crm_deal/api.py
@@ -102,3 +102,10 @@ def update_crm_deal_elements(name, deal_elements):
 	frappe.db.commit()
  
 	return {"name":name, "deal_elements":deal.deal_elements}
+
+
+@frappe.whitelist(methods=["GET"])
+def get_deal_elements():
+	# Fetch all CRM Deal Elements
+	deal_elements = frappe.get_all("CRM Deal Element", fields=["name"])
+	return deal_elements

--- a/crm/fcrm/doctype/crm_deal/api.py
+++ b/crm/fcrm/doctype/crm_deal/api.py
@@ -81,7 +81,7 @@ def get_deal_contacts(name):
 
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def update_crm_deal_elements(name, deal_elements):
 	# Fetch the CRM Deal by name
 	deal = frappe.get_doc("CRM Deal", name)

--- a/crm/fcrm/doctype/crm_deal/api.py
+++ b/crm/fcrm/doctype/crm_deal/api.py
@@ -81,7 +81,7 @@ def get_deal_contacts(name):
 
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST", "PUT"])
 def update_crm_deal_elements(name, deal_elements):
 	# Fetch the CRM Deal by name
 	deal = frappe.get_doc("CRM Deal", name)

--- a/crm/fcrm/doctype/crm_deal/api.py
+++ b/crm/fcrm/doctype/crm_deal/api.py
@@ -20,6 +20,20 @@ def get_deal(name):
 		frappe.throw(_("Deal not found"), frappe.DoesNotExistError)
 	deal = deal.pop()
 
+	# Get all child table doctypes linked to CRM Deal
+	meta = frappe.get_meta("CRM Deal")
+	child_tables = [df for df in meta.fields if df.fieldtype in ["Table","Table MultiSelect" ] ]
+
+	deal['child_tables'] = {}
+
+	for child_table in child_tables:
+		child_doctype = child_table.options
+		child_records = frappe.get_all(
+			child_doctype,
+			fields="*",
+			filters={"parent": deal['name']}
+		)
+		deal['child_tables'][child_table.fieldname] = child_records
 
 	deal["contacts"] = frappe.get_all(
 		"CRM Contacts",

--- a/crm/fcrm/doctype/crm_deal/api.py
+++ b/crm/fcrm/doctype/crm_deal/api.py
@@ -78,3 +78,29 @@ def get_deal_contacts(name):
 		}
 		deal_contacts.append(_contact)
 	return deal_contacts
+
+
+
+@frappe.whitelist(allow_guest=True)
+def update_crm_deal_elements(name, deal_elements):
+	# Fetch the CRM Deal by name
+	deal = frappe.get_doc("CRM Deal", name)
+	
+	# Clear the existing deal elements
+	deal.set("deal_elements", [])
+	
+	# Add new deal elements from the list of strings
+	for element in deal_elements:
+		deal.append("deal_elements", {
+			"deal_elements": element,  # now element is the string itself
+			"parent": name,
+			"parentfield": "deal_elements",
+			"parenttype": "CRM Deal",
+			"doctype": "CRM Deal Elements"
+		})
+	
+	# Save the updated CRM Deal document
+	deal.save(ignore_permissions=True)
+	frappe.db.commit()
+ 
+	return {"name":name, "deal_elements":deal.deal_elements}

--- a/crm/fcrm/doctype/crm_deal/api.py
+++ b/crm/fcrm/doctype/crm_deal/api.py
@@ -79,8 +79,6 @@ def get_deal_contacts(name):
 		deal_contacts.append(_contact)
 	return deal_contacts
 
-
-
 @frappe.whitelist(methods=["POST", "PUT"])
 def update_crm_deal_elements(name, deal_elements):
 	# Fetch the CRM Deal by name

--- a/crm/fcrm/doctype/data_doctype/test_data_doctype.py
+++ b/crm/fcrm/doctype/data_doctype/test_data_doctype.py
@@ -1,9 +1,0 @@
-# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
-# See license.txt
-
-# import frappe
-from frappe.tests.utils import FrappeTestCase
-
-
-class TestDataDoctype(FrappeTestCase):
-	pass

--- a/crm/fcrm/doctype/data_doctype/test_data_doctype.py
+++ b/crm/fcrm/doctype/data_doctype/test_data_doctype.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestDataDoctype(FrappeTestCase):
+	pass


### PR DESCRIPTION
feat: Add child table data to CRM Deal in get_deal method

- Enhanced the get_deal function to retrieve and include child table data for CRM Deal.
- Modified query to return all child tables linked to CRM Deal, including their respective records.
- Added support for fetching contacts, fields metadata, form script, and assigned users for the deal.
![image](https://github.com/user-attachments/assets/c02b7931-7821-4ae1-b260-1c5740eb37ac)

