### PR TITLE
feat(CRM): Add CRM Deal Status Detail for enhanced deal tracking

### DIFF
--- a/crm/api/doc.py
+++ b/crm/api/doc.py
@@ -784,3 +784,9 @@ def parse_js_to_dict(js_code):
         return None
 
     return parsed_dict
+
+
+@frappe.whitelist()
+def get_crm_deal_status_for_status(status):
+    doc_list = frappe.get_list('CRM Deal Status Detail', filters={'crm_deal_status': status}, fields=['detail_name','description'])
+    return doc_list

--- a/crm/fcrm/doctype/crm_deal/crm_deal.js
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.js
@@ -9,6 +9,19 @@ frappe.ui.form.on("CRM Deal", {
 		if (frm.doc.probability){
 			$('[data-fieldname="probability"] input').val(frm.doc.probability + "%")
 	    }
+
+		frm.set_query('status_detail', () => {
+			return {
+				filters:[
+					['crm_deal_status', '=', frm.doc.status],
+					['active', '=', 1],
+				]
+			}
+		})
+
+
+
+
 	},
 	probability(frm){
 		// add '%' sign for probability

--- a/crm/fcrm/doctype/crm_deal/crm_deal.json
+++ b/crm/fcrm/doctype/crm_deal/crm_deal.json
@@ -16,6 +16,7 @@
   "column_break_tukx",
   "next_step",
   "status",
+  "status_detail",
   "sales_channel",
   "deal_owner",
   "organization_tab",
@@ -59,7 +60,8 @@
   "first_response_time",
   "first_responded_on",
   "log_tab",
-  "status_change_log"
+  "status_change_log",
+  "amended_from"
  ],
  "fields": [
   {
@@ -360,11 +362,29 @@
    "fieldtype": "Link",
    "label": "Sales Channel",
    "options": "CRM Sales Channel"
+  },
+  {
+   "depends_on": "eval:doc.status",
+   "fieldname": "status_detail",
+   "fieldtype": "Link",
+   "label": "Status Detail",
+   "options": "CRM Deal Status Detail"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "CRM Deal",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "index_web_pages_for_search": 1,
+ "is_submittable": 1,
  "links": [],
- "modified": "2024-10-30 10:03:54.968190",
+ "modified": "2024-11-05 11:05:30.671900",
  "modified_by": "Administrator",
  "module": "FCRM",
  "name": "CRM Deal",

--- a/crm/fcrm/doctype/crm_deal_status_detail/crm_deal_status_detail.js
+++ b/crm/fcrm/doctype/crm_deal_status_detail/crm_deal_status_detail.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("CRM Deal Status Detail", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/crm/fcrm/doctype/crm_deal_status_detail/crm_deal_status_detail.json
+++ b/crm/fcrm/doctype/crm_deal_status_detail/crm_deal_status_detail.json
@@ -1,0 +1,79 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:detail_name",
+ "creation": "2024-11-05 08:49:54.245508",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "crm_deal_status",
+  "detail_name",
+  "column_break_hahf",
+  "active",
+  "section_break_bzjc",
+  "description"
+ ],
+ "fields": [
+  {
+   "fieldname": "crm_deal_status",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "CRM Deal Status",
+   "options": "CRM Deal Status",
+   "reqd": 1
+  },
+  {
+   "fieldname": "detail_name",
+   "fieldtype": "Data",
+   "label": "Detail Name",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "column_break_hahf",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_bzjc",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "in_filter": 1,
+   "label": "Description"
+  },
+  {
+   "default": "0",
+   "fieldname": "active",
+   "fieldtype": "Check",
+   "label": "Active"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-11-05 11:04:13.836240",
+ "modified_by": "Administrator",
+ "module": "FCRM",
+ "name": "CRM Deal Status Detail",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "search_fields": "description",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/crm/fcrm/doctype/crm_deal_status_detail/crm_deal_status_detail.py
+++ b/crm/fcrm/doctype/crm_deal_status_detail/crm_deal_status_detail.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class CRMDealStatusDetail(Document):
+	pass

--- a/crm/fcrm/doctype/crm_deal_status_detail/test_crm_deal_status_detail.py
+++ b/crm/fcrm/doctype/crm_deal_status_detail/test_crm_deal_status_detail.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestCRMDealStatusDetail(FrappeTestCase):
+	pass

--- a/crm/fixtures/crm_deal_status.json
+++ b/crm/fixtures/crm_deal_status.json
@@ -1,0 +1,74 @@
+[
+ {
+  "color": "gray",
+  "deal_status": "Qualification",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status",
+  "modified": "2024-10-10 09:09:55.118677",
+  "name": "Qualification",
+  "position": 1
+ },
+ {
+  "color": "orange",
+  "deal_status": "Demo/Making",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status",
+  "modified": "2024-10-10 09:09:55.122644",
+  "name": "Demo/Making",
+  "position": 2
+ },
+ {
+  "color": "blue",
+  "deal_status": "Proposal/Quotation",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status",
+  "modified": "2024-10-10 09:09:55.126618",
+  "name": "Proposal/Quotation",
+  "position": 3
+ },
+ {
+  "color": "yellow",
+  "deal_status": "Negotiation",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status",
+  "modified": "2024-10-10 09:09:55.130506",
+  "name": "Negotiation",
+  "position": 4
+ },
+ {
+  "color": "purple",
+  "deal_status": "Ready to Close",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status",
+  "modified": "2024-10-10 09:09:55.134303",
+  "name": "Ready to Close",
+  "position": 5
+ },
+ {
+  "color": "green",
+  "deal_status": "Won",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status",
+  "modified": "2024-10-10 09:09:55.138196",
+  "name": "Won",
+  "position": 6
+ },
+ {
+  "color": "red",
+  "deal_status": "Lost",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status",
+  "modified": "2024-10-10 09:09:55.142032",
+  "name": "Lost",
+  "position": 7
+ },
+ {
+  "color": "gray",
+  "deal_status": "Closed",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status",
+  "modified": "2024-11-05 11:20:41.126091",
+  "name": "Closed",
+  "position": 0
+ }
+]

--- a/crm/fixtures/crm_deal_status_detail.json
+++ b/crm/fixtures/crm_deal_status_detail.json
@@ -1,0 +1,222 @@
+[
+ {
+  "active": 1,
+  "crm_deal_status": "Closed",
+  "description": "Indicates a successful outcome.",
+  "detail_name": "Won",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.801763",
+  "name": "Won"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Closed",
+  "description": "The deal was actively pursued but ultimately lost to a competitor or other reason.",
+  "detail_name": "Lost",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.782728",
+  "name": "Lost"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Closed",
+  "description": "The decision was made to not pursue this deal further.",
+  "detail_name": "Passed",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.767262",
+  "name": "Passed"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Closed",
+  "description": "Closed but with potential to reopen in the future, e.g., for upsell opportunities.",
+  "detail_name": "Pending Resale",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.750460",
+  "name": "Pending Resale"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Closed",
+  "description": "The client or company withdrew from the deal.",
+  "detail_name": "Withdrawn",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.727558",
+  "name": "Withdrawn"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Qualification",
+  "description": "Qualified with clear interest from the client.",
+  "detail_name": "Confirmed Interest",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.707136",
+  "name": "Confirmed Interest"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Qualification",
+  "description": "Gathering requirements and understanding client needs.",
+  "detail_name": "Discovery Phase",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.687724",
+  "name": "Discovery Phase"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Qualification",
+  "description": "The client has confirmed budget alignment.",
+  "detail_name": "Budget Established",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.664944",
+  "name": "Budget Established"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Qualification",
+  "description": "The first formal meeting is scheduled.",
+  "detail_name": "Initial Meeting Scheduled",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.641662",
+  "name": "Initial Meeting Scheduled"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Qualification",
+  "description": "Qualified but waiting on the client to proceed.",
+  "detail_name": "Qualified and Waiting",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.622064",
+  "name": "Qualified and Waiting"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Proposal/Quotation",
+  "description": "Proposal sent and awaiting client feedback.",
+  "detail_name": "Awaiting Feedback",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.603307",
+  "name": "Awaiting Feedback"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Proposal/Quotation",
+  "description": "Client actively reviewing the proposal.",
+  "detail_name": "Under Client Review",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.584428",
+  "name": "Under Client Review"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Proposal/Quotation",
+  "description": "Client has requested changes or revisions.",
+  "detail_name": "Pending Modifications",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.561696",
+  "name": "Pending Modifications"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Proposal/Quotation",
+  "description": "Follow-up has been scheduled to discuss the proposal.",
+  "detail_name": "Follow-Up Scheduled",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.542136",
+  "name": "Follow-Up Scheduled"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Proposal/Quotation",
+  "description": "A revised version of the proposal has been sent.",
+  "detail_name": "Revised Proposal Sent",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.522663",
+  "name": "Revised Proposal Sent"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Negotiation",
+  "description": "Awaiting internal or client-side approval.",
+  "detail_name": "Pending Approval",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.505571",
+  "name": "Pending Approval"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Negotiation",
+  "description": "The client is evaluating a proposal.",
+  "detail_name": "Reviewing Proposal",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.487539",
+  "name": "Reviewing Proposal"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Negotiation",
+  "description": "Initial discussions with no formal proposal yet.",
+  "detail_name": "Under Discussion",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.468553",
+  "name": "Under Discussion"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Negotiation",
+  "description": "Developing or customizing a solution for the client.",
+  "detail_name": "Solution Design",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.450659",
+  "name": "Solution Design"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Negotiation",
+  "description": "Awaiting final decision from the client.",
+  "detail_name": "Final Decision Pending",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.428257",
+  "name": "Final Decision Pending"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Ready to Close",
+  "description": "The client needs more time to make a decision.",
+  "detail_name": "Client Decision Pending",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.392592",
+  "name": "Client Decision Pending"
+ },
+ {
+  "active": 1,
+  "crm_deal_status": "Ready to Close",
+  "description": "Internal review or approval process is ongoing.",
+  "detail_name": "Internal Review",
+  "docstatus": 0,
+  "doctype": "CRM Deal Status Detail",
+  "modified": "2024-11-05 11:27:12.120500",
+  "name": "Internal Review"
+ }
+]

--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -264,6 +264,8 @@ notification_log.send_notification_email = send_notification_email
 notification_log.get_email_header = custom_get_email_header
 
 fixtures = [ 
+    "CRM Deal Status",
+    "CRM Deal Status Detail",     
     {
         "dt": "Custom Field",
         "filters": [


### PR DESCRIPTION
- Added new  doctype with fields:
  -  (Link): Links to CRM Deal Status
  -  (Data): Name of the deal status detail
  -  (Small Text): Description of the status detail
  -  (Check): Indicates if the status is active, default set to true
![image](https://github.com/user-attachments/assets/1b0fc72e-0348-46b1-b105-c111656c48fe)

- Implemented default CRM Deal Status Details for various statuses:
  - Closed: Won, Lost, Passed, Pending Resale, Withdrawn
  - Qualification: Confirmed Interest, Discovery Phase, etc.
  - Proposal/Quotation: Awaiting Feedback, Under Client Review, etc.
  - Negotiation: Pending Approval, Solution Design, etc.
  - Ready to Close: Client Decision Pending, Internal Review, etc.
![image](https://github.com/user-attachments/assets/a52d1179-7231-43be-a092-994f314655c1)

- Created backend function  to fetch CRM Deal Status Details based on status

- Extended CRM Deal doctype to include  field for improved deal tracking and categorization

sample :- http://127.0.0.1:8001/api/method/crm.api.doc.get_crm_deal_status_for_status?status=Closed

![image](https://github.com/user-attachments/assets/644d2ab0-bda5-44f4-80f5-21615f6407d2)





