### PR TITLE
[SCRUM-27][update last modify field on activity update]

### DIFF
--- a/crm/api/activities.py
+++ b/crm/api/activities.py
@@ -342,3 +342,15 @@ def get_linked_tasks(name):
 		],
 	)
 	return tasks or []
+
+#set value for last modified on reference doctype
+def update_last_activity(doc, method):
+    if doc.doctype == "CRM Task":
+        if doc.reference_doctype and doc.reference_docname:
+            frappe.db.set_value(doc.reference_doctype,{'name':doc.reference_docname}, 'modified' ,doc.modified)
+    elif doc.doctype == "Communication":
+        if doc.reference_doctype and doc.reference_name and doc.communication_medium == "Email" and doc.communication_type == "Communication":
+            frappe.db.set_value(doc.reference_doctype,{'name':doc.reference_name}, 'modified' ,doc.modified)
+    elif doc.doctype == "FCRM Note":
+        if doc.reference_doctype and doc.reference_docname :
+            frappe.db.set_value(doc.reference_doctype,{'name':doc.reference_docname}, 'modified' ,doc.modified)

--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -159,7 +159,19 @@ doc_events = {
 	},
 	"User": {
 		"before_validate": ["crm.api.demo.validate_user"]
-	}
+	},
+	"CRM Task": {
+        "after_insert": "crm.api.activities.update_last_activity",
+        "validate": "crm.api.activities.update_last_activity"
+    },
+    "Communication": {
+        "after_insert": "crm.api.activities.update_last_activity",
+        "validate": "crm.api.activities.update_last_activity"
+    },
+    "FCRM Note": {
+        "after_insert": "crm.api.activities.update_last_activity",
+        "validate": "crm.api.activities.update_last_activity"
+    }
 }
 
 # Scheduled Tasks


### PR DESCRIPTION
As we discussed we dropped approach of adding last activity field and replace it with modified . So, purpose of this just last modified field update on change of activity. So, I have update last modified field on creation/ updation of activities like Note, Email and Task. 
![Screenshot from 2024-12-18 13-37-54](https://github.com/user-attachments/assets/bb7bf7f5-921c-4b6e-a26e-c3d4282d3dea)
